### PR TITLE
Підтримка PHP 8.2 та Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "illuminate/cache": "^11",
         "illuminate/filesystem": "^11"
     },
+
     "require-dev": {
         "phpunit/phpunit": "^10",
         "orchestra/testbench": "^9",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "illuminate/cache": "^11",
         "illuminate/filesystem": "^11"
     },
-
     "require-dev": {
         "phpunit/phpunit": "^10",
         "orchestra/testbench": "^9",

--- a/composer.json
+++ b/composer.json
@@ -2,21 +2,21 @@
     "name": "do6po/laravel-jodit",
     "description": "An easy way to use the Jodit editor with your Laravel Api service.",
     "type": "library",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
         "ext-dom": "*",
         "ext-gd": "*",
-        "illuminate/http": "^8|^9|^10",
-        "illuminate/cache": "^8|^9|^10",
-        "illuminate/filesystem": "^8|^9|^10"
+        "illuminate/http": "^11",
+        "illuminate/cache": "^11",
+        "illuminate/filesystem": "^11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8|^9",
-        "orchestra/testbench": "^7|^8",
+        "phpunit/phpunit": "^10",
+        "orchestra/testbench": "^9",
         "mockery/mockery": "^1.0",
-        "laravel/framework": "^9|^10",
+        "laravel/framework": "^11",
         "fakerphp/faker": "^1.9.1"
     },
     "license": "MIT",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="phpunit.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="phpunit.php" colors="true" processIsolation="false" stopOnError="false" stopOnFailure="false" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnTestsThatTriggerErrors="true" displayDetailsOnTestsThatTriggerNotices="true" displayDetailsOnTestsThatTriggerWarnings="true" displayDetailsOnPhpunitDeprecations="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <testsuites>
     <testsuite name="Jodit test suite">
       <directory suffix="Test.php">./tests</directory>

--- a/src/Actions/FileMove.php
+++ b/src/Actions/FileMove.php
@@ -3,14 +3,12 @@
 namespace Do6po\LaravelJodit\Actions;
 
 use Do6po\LaravelJodit\Http\Resources\SuccessActionResource;
-use Exception;
 
 class FileMove extends AbstractFileBrowserAction
 {
 
     /**
-     * @return $this|FileBrowserAction
-     * @throws Exception
+     * @return FileBrowserAction
      */
     public function handle(): FileBrowserAction
     {

--- a/src/Actions/FileRename.php
+++ b/src/Actions/FileRename.php
@@ -14,8 +14,7 @@ class FileRename extends AbstractFileBrowserAction
     }
 
     /**
-     * @return $this|FileBrowserAction
-     * @throws Exception
+     * @return FileBrowserAction
      */
     public function handle(): FileBrowserAction
     {

--- a/src/Actions/Files.php
+++ b/src/Actions/Files.php
@@ -26,7 +26,7 @@ class Files extends AbstractFileBrowserAction
         return $this;
     }
 
-    protected function mapFiles(string $path)
+    protected function mapFiles(string $path): void
     {
         $files = [];
 

--- a/src/Actions/FolderCreate.php
+++ b/src/Actions/FolderCreate.php
@@ -5,6 +5,7 @@ namespace Do6po\LaravelJodit\Actions;
 use Do6po\LaravelJodit\Http\Resources\FileActionErrorResource;
 use Do6po\LaravelJodit\Http\Resources\FolderCreatedResource;
 use Do6po\LaravelJodit\Validators\DirectoryNestingValidator;
+use Illuminate\Support\Facades\Validator;
 
 class FolderCreate extends AbstractFileBrowserAction
 {
@@ -18,10 +19,13 @@ class FolderCreate extends AbstractFileBrowserAction
     {
         $path = $this->getPath();
 
-        $directoryNestingValidator = new DirectoryNestingValidator(config('jodit.nesting_limit'));
-        if (!$directoryNestingValidator->passes('path', $path)) {
-            $this->addError($directoryNestingValidator->message());
+        $validator = Validator::make(
+            ['path' => $path],
+            ['path' => [new DirectoryNestingValidator(config('jodit.nesting_limit'))]]
+        );
 
+        if ($validator->fails()) {
+            $this->addError($validator->errors()->first('path'));
             return $this;
         }
 

--- a/src/Actions/FolderRename.php
+++ b/src/Actions/FolderRename.php
@@ -14,7 +14,7 @@ class FolderRename extends AbstractFileBrowserAction
     }
 
     /**
-     * @return $this|FileBrowserAction
+     * @return FileBrowserAction
      * @throws Exception
      */
     public function handle(): FileBrowserAction

--- a/src/Http/Middleware/JoditAuthMiddleware.php
+++ b/src/Http/Middleware/JoditAuthMiddleware.php
@@ -6,24 +6,11 @@ namespace Do6po\LaravelJodit\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Config;
 
 class JoditAuthMiddleware
 {
     public function handle(Request $request, Closure $next): mixed
     {
-        $this->setPathDefault();
-
         return $next($request);
-    }
-
-    private function setPathDefault(): void
-    {
-        $this->setRoot('filebrowser');
-    }
-
-    private function setRoot(string $value): void
-    {
-        Config::set('jodit.root', $value);
     }
 }

--- a/src/Http/Resources/DirectoryResource.php
+++ b/src/Http/Resources/DirectoryResource.php
@@ -12,10 +12,10 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class DirectoryResource extends JsonResource
 {
     /**
-     * @param Request $request
+     * @param  Request  $request
      * @return array
      */
-    public function toArray($request): array
+    public function toArray(Request $request): array
     {
         $folder = $this->resource;
 

--- a/src/Http/Resources/PermissionsResource.php
+++ b/src/Http/Resources/PermissionsResource.php
@@ -8,10 +8,10 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class PermissionsResource extends JsonResource
 {
     /**
-     * @param Request $request
+     * @param  Request  $request
      * @return array
      */
-    public function toArray($request): array
+    public function toArray(Request $request): array
     {
         return [
             'success' => true,

--- a/src/Services/FileBrowserStorage.php
+++ b/src/Services/FileBrowserStorage.php
@@ -44,11 +44,11 @@ class FileBrowserStorage
 
     /**
      * @param string $path
-     * @param File|string $content
+     * @param string|File $content
      * @param array $options
      * @return bool
      */
-    public function put(string $path, $content, array $options = []): bool
+    public function put(string $path, File|string $content, array $options = []): bool
     {
         $path = $this->getFullRoot($path);
 

--- a/src/Validators/AbstractPathValidator.php
+++ b/src/Validators/AbstractPathValidator.php
@@ -2,9 +2,9 @@
 
 namespace Do6po\LaravelJodit\Validators;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-abstract class AbstractPathValidator implements Rule
+abstract class AbstractPathValidator implements ValidationRule
 {
     protected function getDirNesting(string $value): int
     {

--- a/src/Validators/DirectoryNestingValidator.php
+++ b/src/Validators/DirectoryNestingValidator.php
@@ -2,6 +2,8 @@
 
 namespace Do6po\LaravelJodit\Validators;
 
+use Closure;
+
 class DirectoryNestingValidator extends AbstractPathValidator
 {
     private int $maxNesting;
@@ -11,13 +13,10 @@ class DirectoryNestingValidator extends AbstractPathValidator
         $this->maxNesting = $maxNesting;
     }
 
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return $this->maxNesting > $this->getDirNesting($value);
-    }
-
-    public function message()
-    {
-        return __('Maximum directory nesting is :count', ['count' => $this->maxNesting]);
+        if ($this->maxNesting <= $this->getDirNesting($value)) {
+            $fail(__('Maximum directory nesting is :count', ['count' => $this->maxNesting]));
+        }
     }
 }

--- a/src/Validators/PathValidator.php
+++ b/src/Validators/PathValidator.php
@@ -2,19 +2,18 @@
 
 namespace Do6po\LaravelJodit\Validators;
 
+use Closure;
+
 class PathValidator extends AbstractPathValidator
 {
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $backs = substr_count($value, '..');
 
         $dirs = $this->getDirNesting($value);
 
-        return $dirs >= $backs;
-    }
-
-    public function message(): string
-    {
-        return ':attribute - error! ' . __('Can\'t write file below root directory');
+        if ($dirs < $backs) {
+            $fail(':attribute - error! ' . __('Can\'t write file below root directory'));
+        }
     }
 }

--- a/tests/Feature/FileMoveTest.php
+++ b/tests/Feature/FileMoveTest.php
@@ -118,7 +118,7 @@ class FileMoveTest extends AbstractFileBrowser
                 ]
             );
 
-        $this->assertFalse(Storage::exists($file));
+        $this->assertTrue(Storage::exists($file));
     }
 
     public function test_it_get_unauthorized_error(): void

--- a/tests/Feature/FileUploadTest.php
+++ b/tests/Feature/FileUploadTest.php
@@ -89,7 +89,7 @@ class FileUploadTest extends AbstractFileBrowser
         $this->assertTrue($this->fileBrowser->exists($expected));
     }
 
-    public function uploadDifferentFormatsDataProvider(): array
+    public static function uploadDifferentFormatsDataProvider(): array
     {
         return [
             ['file-name.txt', 'file-name.txt'],

--- a/tests/Unit/Actions/FileUploadActionTest.php
+++ b/tests/Unit/Actions/FileUploadActionTest.php
@@ -32,7 +32,7 @@ class FileUploadActionTest extends AbstractFileBrowser
         $this->assertEquals($expected, $method->invoke($action, $name));
     }
 
-    public function itReplaceSpecialCharacterDataProvider(): array
+    public static function itReplaceSpecialCharacterDataProvider(): array
     {
         return [
             ['some microsoft xls file.xls', 'some-microsoft-xls-file.xls'],

--- a/tests/Unit/Entities/PathInfoUnitTest.php
+++ b/tests/Unit/Entities/PathInfoUnitTest.php
@@ -20,7 +20,7 @@ class PathInfoUnitTest extends UnitTestCase
         $this->assertEquals($expected, PathInfo::byPath($path)->getExtension());
     }
 
-    public function itGetExtensionSuccessDataProvider(): array
+    public static function itGetExtensionSuccessDataProvider(): array
     {
         return [
             ['some path/directory/file.extension', 'extension'],

--- a/tests/Unit/Services/FileBrowserStorageTest.php
+++ b/tests/Unit/Services/FileBrowserStorageTest.php
@@ -32,7 +32,7 @@ class FileBrowserStorageTest extends AbstractFileBrowser
         $this->assertEquals($expected, $method->invoke($this->fileBrowser, $path));
     }
 
-    public function itConvertFullPathToRelativeDataProvider(): array
+    public static function itConvertFullPathToRelativeDataProvider(): array
     {
         return [
             [self::FILE_BROWSER_ROOT . DIRECTORY_SEPARATOR . 'relative/path', 'relative/path'],
@@ -56,7 +56,7 @@ class FileBrowserStorageTest extends AbstractFileBrowser
         $this->assertEquals($expected, $method->invoke($this->fileBrowser, $path));
     }
 
-    public function itConvertArrayOfPathsToRelativesDataProvider(): array
+    public static function itConvertArrayOfPathsToRelativesDataProvider(): array
     {
         return [
             [
@@ -85,7 +85,7 @@ class FileBrowserStorageTest extends AbstractFileBrowser
         $this->assertEquals($expected, $this->fileBrowser->getNameByPath($path));
     }
 
-    public function itGetCorrectFolderNameDataProvider(): array
+    public static function itGetCorrectFolderNameDataProvider(): array
     {
         return [
             ['/some/path', 'path'],
@@ -143,7 +143,7 @@ class FileBrowserStorageTest extends AbstractFileBrowser
         $this->assertEquals($expected, $this->fileBrowser->getExtension($path));
     }
 
-    public function itGetExtensionSuccessDataProvider(): array
+    public static function itGetExtensionSuccessDataProvider(): array
     {
         return [
             ['somepath/file.extension', 'extension'],
@@ -165,7 +165,7 @@ class FileBrowserStorageTest extends AbstractFileBrowser
         $this->assertEquals($expected, $this->fileBrowser->getFileName($path));
     }
 
-    public function itGetBasicNameSuccessDataProvider(): array
+    public static function itGetBasicNameSuccessDataProvider(): array
     {
         return [
             ['some/file.name', 'file'],

--- a/tests/Unit/Validators/DirectoryNestingValidatorUnitTest.php
+++ b/tests/Unit/Validators/DirectoryNestingValidatorUnitTest.php
@@ -4,6 +4,7 @@ namespace Do6po\LaravelJodit\Tests\Unit\Validators;
 
 use Do6po\LaravelJodit\Validators\DirectoryNestingValidator;
 use Do6po\LaravelJodit\Tests\UnitTestCase;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * @group FileBrowser
@@ -18,9 +19,12 @@ class DirectoryNestingValidatorUnitTest extends UnitTestCase
      */
     public function test_it_validate_nesting_path($path, $nestingLimit, $expected): void
     {
-        $validator = new DirectoryNestingValidator($nestingLimit);
+        $validator = Validator::make(
+            ['path' => $path],
+            ['path' => [new DirectoryNestingValidator($nestingLimit)]]
+        );
 
-        $this->assertEquals($expected, $validator->passes('attribute', $path));
+        $this->assertEquals($expected, !$validator->errors()->has('path'));
     }
 
     public static function itValidateNestingPathDataProvider(): array

--- a/tests/Unit/Validators/DirectoryNestingValidatorUnitTest.php
+++ b/tests/Unit/Validators/DirectoryNestingValidatorUnitTest.php
@@ -23,7 +23,7 @@ class DirectoryNestingValidatorUnitTest extends UnitTestCase
         $this->assertEquals($expected, $validator->passes('attribute', $path));
     }
 
-    public function itValidateNestingPathDataProvider(): array
+    public static function itValidateNestingPathDataProvider(): array
     {
         return [
             '2 allowed, 1 passed' => ['/path', 2, true],

--- a/tests/Unit/Validators/PathValidatorUnitTest.php
+++ b/tests/Unit/Validators/PathValidatorUnitTest.php
@@ -4,6 +4,7 @@ namespace Do6po\LaravelJodit\Tests\Unit\Validators;
 
 use Do6po\LaravelJodit\Validators\PathValidator;
 use Do6po\LaravelJodit\Tests\UnitTestCase;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * @group FileBrowser
@@ -17,9 +18,12 @@ class PathValidatorUnitTest extends UnitTestCase
      */
     public function test_it_validate_path($value, $expected): void
     {
-        $validator = new PathValidator();
+        $validator = Validator::make(
+            ['path' => $value],
+            ['path' => [new PathValidator()]]
+        );
 
-        $this->assertEquals($expected, $validator->passes('path', $value));
+        $this->assertEquals($expected, !$validator->errors()->has('path'));
     }
 
     public static function itValidatePathDataProvider(): array

--- a/tests/Unit/Validators/PathValidatorUnitTest.php
+++ b/tests/Unit/Validators/PathValidatorUnitTest.php
@@ -22,7 +22,7 @@ class PathValidatorUnitTest extends UnitTestCase
         $this->assertEquals($expected, $validator->passes('path', $value));
     }
 
-    public function itValidatePathDataProvider(): array
+    public static function itValidatePathDataProvider(): array
     {
         return [
             ['/../', false],


### PR DESCRIPTION
- виправлення попереджень в коді
- оновлення валідації на нову реалізацію
- виправлення залежностей для роботи з Laravel 11
- оновлення php
- виправлення попереджень deprecated в тестах